### PR TITLE
Support gzip compression on TYPO3 generated/compressed assets

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -57,6 +57,15 @@ web:
         scripts: false
         allow: true
         passthru: '/index.php'
+        rules:
+          '\.js\.gzip$':
+            headers:
+              Content-Type: text/javascript
+              Content-Encoding: gzip
+          '\.css\.gzip$':
+            headers:
+              Content-Type: text/css
+              Content-Encoding: gzip
       '/typo3conf/LocalConfiguration.php':
         allow: false
       '/typo3conf/AdditionalConfiguration.php':


### PR DESCRIPTION
This is equivalent to the standard `.htaccess` rule from TYPO3 below regarding those files, expect it's restricted to be supported only within `typo3temp/assets`, which is basically the only path where this files are generated.

```apache
<FilesMatch "\.js\.gzip$">
    AddType "text/javascript" .gzip
</FilesMatch>
<FilesMatch "\.css\.gzip$">
    AddType "text/css" .gzip
</FilesMatch>
AddEncoding gzip .gzip
```

Fixes #22 